### PR TITLE
Package Installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,10 +28,10 @@ conda activate jbook-env
 
 ```sh
 # install just the jupyter book package into your environment:
-pip install jupyter-book
+#pip install jupyter-book
 
 # consider alternatively leveraging the requirements file:
-#pip install -r requirements.txt
+pip install -r requirements.txt
 ```
 
 ## Managing the Book
@@ -51,6 +51,8 @@ If you have created a copy of this repository, you won't need to repeat this ini
 There are a number of opportunities to customize the book configuration via the ["_config.yml" file](/example-book/_config.yml) (for example, updating the logo). The sidebar navigation can be customized via the ["_toc.yml" file](/example-book/_toc.yml). See the [Jupyter Book Configuration Reference](https://jupyterbook.org/customize/config.html) for more details.
 
 Also customize the content for your book, adding new markdown and notebook files to your book directory, as desired.
+
+If you are including IPYNB notebooks in your book, and if these notebooks use any third-party Python packages, you must update the ["requirements.txt" file](/requirements.txt) to include the names of those packages.
 
 ### Building
 

--- a/example-book/requirements.txt
+++ b/example-book/requirements.txt
@@ -1,3 +1,0 @@
-jupyter-book
-matplotlib
-numpy

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,12 @@
 
-
+# USE JUPYTER BOOK TO BUILD THE BOOK
 # https://jupyterbook.org/en/stable/start/overview.html
 jupyter-book
+
+
+# ALSO ADD ANY PACKAGES THAT YOUR NOTEBOOKS REQURE (BELOW)
+# JUPYER BOOK WILL EXECUTE THE NOTEBOOKS
+# ... SO THEY WILL NEED TO HAVE THEIR PACKAGE DEPENDENCIES SATISFIED
+matplotlib
+numpy
+# etc...


### PR DESCRIPTION
Adds instructions related to installing packages required by any notebooks used in the book.

The GitHub Actions workflow installs packages from the "requirements.txt" file during the build process. 

This fixes any broken notebook content (see below).

Broken Notebook Content (no package installation):
<img width="853" alt="Screenshot 2024-05-02 at 3 50 21 PM" src="https://github.com/gw-ospo/jupyter-book-template/assets/1328807/176d7262-ef3c-41a7-af70-5e7c8daf9f6e">

Fixed Notebook Content (after package installation):

<img width="970" alt="Screenshot 2024-05-02 at 3 58 12 PM" src="https://github.com/gw-ospo/jupyter-book-template/assets/1328807/24bb0b10-a169-4aff-8a9b-119d41a86928">


